### PR TITLE
[KK] Temporarily disable ABMX controllers to improve performance

### DIFF
--- a/Shared_KKEC/Core/KKABMX_Core.Hooks.cs
+++ b/Shared_KKEC/Core/KKABMX_Core.Hooks.cs
@@ -6,6 +6,9 @@ using ExtensibleSaveFormat;
 #if KK || KKS
 using Studio;
 #endif
+#if KK
+using ActionGame.Chara;
+#endif
 
 namespace KKABMX.Core
 {
@@ -43,6 +46,22 @@ namespace KKABMX.Core
 #endif
             }
 
+#if KK
+            [HarmonyPostfix, HarmonyPatch(typeof(NPC), nameof(NPC.Pause))]
+            public static void PausePost(NPC __instance)
+            {
+                var chaControl = __instance.chaCtrl;
+                if (chaControl == null)
+                    return;
+
+                var boneController = chaControl.GetComponent<BoneController>();
+                if (boneController == null)
+                    return;
+
+                boneController.enabled = !__instance.isPause;
+            }
+#endif
+            
             [HarmonyPostfix]
             [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.SetShapeBodyValue))]
             [HarmonyPatch(typeof(ChaControl), nameof(ChaControl.SetShapeFaceValue))]


### PR DESCRIPTION
**Issue:** Having large amounts of characters (60+) introduces performance issues when ABMX is used for many of the characters.

**Solution:** Disable BoneController component for NPCs which become Paused (while in ADV and HScene). Once they are unpaused, BoneController is enabled again.

**Reproducion:** 
1. Enter a TalkScene with a character when there are 60+ other NPCs roaming around. 
2. Observe the FPSCounter which shows `KKABMX.Core` taking up 5ms of FrameTime. 

**Results:** Images showing performance improvements. In this case almost a 30FPS improvement was observed.
![before](https://i.imgur.com/pcrIU70.png) ![after](https://i.imgur.com/YAkMUL4.png)

A better solution would be to toggle BoneController for characters once they enter or exit the players view, that way the performance improvements can be achieved while roaming as well. For now, this solution is enough however.