### PR TITLE
Fix for accessory dynamic bones causing a faulty baseline to be collected.

### DIFF
--- a/Shared/Core/BoneController.cs
+++ b/Shared/Core/BoneController.cs
@@ -968,8 +968,19 @@ namespace KKABMX.Core
             var accId = location - BoneLocation.Accessory;
             var rootObj = _ctrl.objAccessory.SafeGet(accId);
 
+            if (rootObj == null) 
+            {
+                return null;
+            }
+
             foreach (var dynamicBone in rootObj.GetComponents<DynamicBone>())
             {
+
+                if (dynamicBone.m_Root == null) 
+                {
+                    continue;
+                }
+
                 if (dynamicBone.m_Root.name.Equals(name))
                 {
                     return dynamicBone;

--- a/Shared/Core/BoneModifier.cs
+++ b/Shared/Core/BoneModifier.cs
@@ -100,6 +100,12 @@ namespace KKABMX.Core
         public Transform BoneTransform { get; internal set; }
 
         /// <summary>
+        /// DynamicBone component that targets this transform, if any.
+        /// </summary>
+        [IgnoreMember]
+        public DynamicBone DynamicBone { get; internal set; }
+
+        /// <summary>
         /// Actual modifier values, split for different coordinates if required
         /// </summary>
         [Key(1)]

--- a/Shared/Core/BoneModifier.cs
+++ b/Shared/Core/BoneModifier.cs
@@ -103,7 +103,7 @@ namespace KKABMX.Core
         /// DynamicBone component that targets this transform, if any.
         /// </summary>
         [IgnoreMember]
-        public DynamicBone DynamicBone { get; internal set; }
+        internal DynamicBone DynamicBone { get; set; }
 
         /// <summary>
         /// Actual modifier values, split for different coordinates if required


### PR DESCRIPTION
Fix for #58 

I tried to keep things as simple as possible, when the baseline is first collected, we simply disable the component, which causes the bones to assume their resting position, collect the baseline, and set things back to how they were.